### PR TITLE
Docker Awareness, M1 Help, and Config Polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,18 @@ A web application that assists network defenders, analysts, and researcher in th
 
 This project makes use of MITRE ATT&CK - [ATT&CK Terms of Use](https://attack.mitre.org/resources/terms-of-use/)
 
+## Notices & Updates
+
+### All Users - Dockerization in Progress
+- Deployment is currently unwieldy
+- Decider on Docker is currently underway to make deployment easier
+  - Completion is tentatively next week
+
+### MacBook M1 Users - Pip Install Woes
+- Before `pip install -r requirements.txt`
+  - Run `brew install postgresql`
+  - This fixes an issue where *psycopg2-binary* isn't using a pre-built binary and tries to compile from scratch. Compilation fails if *pg_config* isn't found.
+
 ## Developer Instructions
 
 Before developing, please set up a virtualenv and install the pre-commit git hook scripts.  

--- a/app/conf.py
+++ b/app/conf.py
@@ -21,9 +21,9 @@ class DefaultConfig(Config):
         drivername="postgresql",
         username=DB_USER_NAME,
         password=DB_USER_PASS,
-        host="decider-db",
+        host="localhost",
         port=5432,
-        database="production_5000_all_mii",
+        database="decider",
     )
 
 
@@ -32,54 +32,13 @@ class ProductionConfig(Config):
         drivername="postgresql",
         username=DB_USER_NAME,
         password=DB_USER_PASS,
-        host="decider-db",
+        host="localhost",
         port=5432,
-        database="production_5000_all_mii",
+        database="decider",
     )
-
-
-class StagingConfig(Config):
-    SQLALCHEMY_DATABASE_URI = sqlalch.engine.URL.create(
-        drivername="postgresql",
-        username=DB_USER_NAME,
-        password=DB_USER_PASS,
-        host="decider-db",
-        port=5432,
-        database="staging_9000_cti_only",
-    )
-
-
-class DevelopmentConfig(Config):
-    SQLALCHEMY_DATABASE_URI = sqlalch.engine.URL.create(
-        drivername="postgresql",
-        username=DB_USER_NAME,
-        password=DB_USER_PASS,
-        host="decider-db",
-        port=5432,
-        database="staging_9000_cti_only",
-    )
-    LOG_LEVEL = "DEBUG"
-    TESTING = True
-    DEBUG = True
-    WTF_CSRF_CHECK_DEFAULT = False
-
-
-class PytestConfig(Config):
-    SQLALCHEMY_DATABASE_URI = sqlalch.engine.URL.create(
-        drivername="postgresql",
-        username=DB_USER_NAME,
-        password=DB_USER_PASS,
-        host="decider-db",
-        port=5432,
-        database="staging_9000_cti_only",
-    )
-    WTF_CSRF_CHECK_DEFAULT = False
 
 
 conf_configs = [
     DefaultConfig,
     ProductionConfig,
-    StagingConfig,
-    DevelopmentConfig,
-    PytestConfig,
 ]


### PR DESCRIPTION
- Update app/conf.py
  - Remove extra Config profiles
  - Set Default and Production Config profiles to have `host` and `database` matching the defaults in the Admin Guide
- Update README:
  - Add notice that a Docker deployment solution is in-progress
  - Add help message for M1 Mac users during pip install