### PR TITLE
Docker uWSGI HTTPS Support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,9 +11,11 @@ ADMIN_EMAIL=admin@admin.com
 ADMIN_PASS=admin
 
 # only influences Docker, not uWSGI
-# app is accessible at: http://WEB_IP:WEB_PORT/
+# app is accessible at: http(s)://WEB_IP:WEB_PORT/
+# WEB_HTTPS_ON is off when empty, on when has any value
 WEB_IP=127.0.0.1
 WEB_PORT=8001
+WEB_HTTPS_ON=''
 
 # do not edit if using Docker - will break
 DB_HOSTNAME=db

--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,8 @@ ADMIN_EMAIL=admin@admin.com
 ADMIN_PASS=admin
 
 # only influences Docker, not uWSGI
-# allows avoiding conflicts (like mac's ControlCenter on 5000 & 7000)
+# app is accessible at: http://WEB_IP:WEB_PORT/
+WEB_IP=127.0.0.1
 WEB_PORT=8001
 
 # do not edit if using Docker - will break

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ UNKNOWN.egg-info/
 *.key
 *.pem
 *.csr
+/app/utils/certs/
 
 # Secrets
 /.env

--- a/README.md
+++ b/README.md
@@ -46,15 +46,23 @@ cp .env.example .env
 It is ready when **Starting uWSGI** appears
 ![Decider on Docker Boot Terminal Output](./docs/imgs/docker-started-1.0.0.png)
 
-Then visit http://localhost:8001/
+**Default Endpoint**: http://localhost:8001/
 
-(Endpoint set via .env vars: http://`WEB_IP`:`WEB_PORT`/)
-
-Default Login:
+**Default Login**:
 - Email: admin@admin.com
 - Password: admin
 
-And note: Postgres stores its data in a Docker volume to persist the database.
+**Endpoint Determination** (.env vars):
+- `WEB_HTTPS_ON=''` -> http://`WEB_IP`:`WEB_PORT`/
+- `WEB_HTTPS_ON='anything'` -> https://`WEB_IP`:`WEB_PORT`/
+
+**HTTPS Cert Location**:
+- Write these 2 files before `docker compose up` to set your SSL cert up
+  - /app/utils/certs/decider.key
+  - /app/utils/certs/decider.crt
+- If either file is missing, a self-signed cert is generated and used instead
+
+**DB Persistence Note**: Postgres stores its data in a Docker volume to persist the database.
 
 #### Linux tested on:
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,19 @@ cp .env.example .env
 ```
 *sudo for Linux only*
 
+It is ready when **Starting uWSGI** appears
+![Decider on Docker Boot Terminal Output](./docs/imgs/docker-started-1.0.0.png)
+
+Then visit http://localhost:8001/
+
+(Endpoint set via .env vars: http://`WEB_IP`:`WEB_PORT`/)
+
+Default Login:
+- Email: admin@admin.com
+- Password: admin
+
+And note: Postgres stores its data in a Docker volume to persist the database.
+
 #### Linux tested on:
 
 - Ubuntu Jammy 22.04.2 LTS
@@ -60,19 +73,6 @@ cp .env.example .env
 - macOS Ventura 13.2.1 (22D68)
 - Mac M1 Processor
 - On Docker Desktop installed via .dmg
-
-It is ready when **Starting uWSGI** appears
-![Decider on Docker Boot Terminal Output](./docs/imgs/docker-started-1.0.0.png)
-
-Then visit http://localhost:8001/
-
-(Port is set by .env WEB_PORT)
-
-Default Login:
-- Email: admin@admin.com
-- Password: admin
-
-And note: Postgres stores its data in a Docker volume to persist the database.
 
 ### Manual Install
 

--- a/README.md
+++ b/README.md
@@ -35,13 +35,21 @@ This project makes use of MITRE ATT&CK - [ATT&CK Terms of Use](https://attack.mi
 
 **Best option for 99% of people**
 
-```
+```bash
 git clone https://github.com/cisagov/decider.git
 cd decider
 cp .env.example .env
+
+# if you want HTTPS instead of HTTP
+# - edit .env
+#   + WEB_HTTPS_ON='yes'
+# - populate cert / key files
+#   + /app/utils/certs/decider.key
+#   + /app/utils/certs/decider.crt
+
 [sudo] docker compose up
+# sudo for Linux only
 ```
-*sudo for Linux only*
 
 It is ready when **Starting uWSGI** appears
 ![Decider on Docker Boot Terminal Output](./docs/imgs/docker-started-1.0.0.png)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
       context: .
       dockerfile: ./docker/web/Dockerfile
     ports:
-      - '${WEB_PORT}:5000'
+      - '${WEB_IP}:${WEB_PORT}:5000'
     environment:
       FULL_BUILD_MODE: preserve
       DB_HOSTNAME: ${DB_HOSTNAME}


### PR DESCRIPTION
- HTTPS now supported for Docker-based deployment
  - An env var allows picking HTTP or HTTPS
  - Instructions on where cert/key files go have been added

- Option to control interface/IP that `web` container binds to
  - Sensible default of _localhost_ instead of _all_