### PR TITLE
Improve Requirements & Docker Install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ UNKNOWN.egg-info/
 /.env
 user.json
 /init.sql
+/app/utils/db/dumps
 
 # Docker > db Postgres Data
 docker/db/data

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Decider
 
 ## Notifications
+
 - **Manual Install** for Ubuntu &amp; CentOS is much nicer.
 - Will be adding information about hardware requirements soon
 - Dependencies updated!
@@ -34,6 +35,7 @@ Boolean expressions, prefix-matching, and stemming included.
 This project makes use of MITRE ATT&CK - [ATT&CK Terms of Use](https://attack.mitre.org/resources/terms-of-use/)
 
 ## Usage
+
 **Read the [User Guide](./docs/Decider_User_Guide_v1.0.0.pdf)**
 
 ## Installation
@@ -54,7 +56,7 @@ cp .env.docker .env
 #   + /app/utils/certs/decider.key
 #   + /app/utils/certs/decider.crt
 
-[sudo] docker compose up
+sudo docker compose up
 # sudo for Linux only
 ```
 
@@ -79,36 +81,36 @@ It is ready when **Starting uWSGI** appears
 
 **DB Persistence Note**: Postgres stores its data in a Docker volume to persist the database.
 
-#### Linux tested on:
-
-- Ubuntu Jammy 22.04.2 LTS
-- Docker Engine
-  - Not Docker Desktop (couldn't get nested-virt in my VM)
-
-#### Windows tested on:
-
-- Windows 11 Home, version 22H2, build 22621.1344
-- Home doesn't support HyperV
-  - Thus tested on Docker Desktop [via WSL backend](https://docs.docker.com/desktop/windows/wsl/)
-
-#### macOS (M1) tested on:
-
-- macOS Ventura 13.2.1 (22D68)
-- Mac M1 Processor
-- On Docker Desktop installed via .dmg
-
 ### Manual Install
 
 #### Ubuntu 22.04
+
 [Ubuntu Install Guide](docs/install/Ubuntu_22.04.2.md)
 
 #### CentOS 7
+
 [CentOS Install Guide](docs/install/CentOS_7.md)
 
+#### Pip Requirements Note
+
+##### For Everyone
+```bash
+pip install -r requirements-pre.txt
+pip install -r requirements.txt
+```
+
+##### For Developers
+```bash
+pip install -r requirements-dev.txt
+pre-commit install
+```
+
 #### Other OSes
+
 Read the Ubuntu &amp; CentOS guides and recreate actions according to your platform.
 
 ##### Windows
+
 `open()` in Python uses the system's default text encoding
 - This is `utf-8` on macOS and Linux
 - This is `windows-1252` on Windows
@@ -116,6 +118,8 @@ Read the Ubuntu &amp; CentOS guides and recreate actions according to your platf
   - Adding `encoding='utf-8'` as an arg in each `open()` ***may*** allow Windows deployment
 
 ##### macOS
-(M1 users at least) Make sure to (1) install Postgres before (2) installing the pip requirements
+
+(M1 users at least) Make sure to (1) install Postgres before (2, 3) installing the pip requirements
 1. `brew install postgresql`
-2. `pip install -r requirements.txt`
+2. `pip install -r requirements-pre.txt`
+3. `pip install -r requirements.txt`

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -37,7 +37,7 @@ services:
       timeout: 5s
       retries: 5
     volumes:
-       - db_data:/var/lib/postgresql/data
+      - db_data:/var/lib/postgresql/data
 
 volumes:
   db_data:

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -1,11 +1,9 @@
 FROM python:3.8-bullseye
 
-COPY ./requirements.txt /requirements.txt
+COPY ./requirements-pre.txt ./requirements.txt /
 
-RUN pip install --no-cache-dir pip==23.0.1 && \
-    pip install --no-cache-dir setuptools==67.6.1 && \
-    pip install --no-cache-dir wheel==0.40.0 && \
-    pip install --no-cache-dir --requirement /requirements.txt
+RUN pip install --no-cache-dir -r /requirements-pre.txt && \
+    pip install --no-cache-dir -r /requirements.txt
 
 RUN apt-get update && \
     apt-get install dos2unix

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -5,13 +5,8 @@ COPY ./requirements-pre.txt ./requirements.txt /
 RUN pip install --no-cache-dir -r /requirements-pre.txt && \
     pip install --no-cache-dir -r /requirements.txt
 
-RUN apt-get update && \
-    apt-get install dos2unix
-
 COPY ./app /app
 COPY ./docker/web/root_files/* /
 COPY ./decider.py /decider.py
-
-RUN dos2unix /entrypoint.sh
 
 ENTRYPOINT ["/bin/sh", "/entrypoint.sh"]

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -1,12 +1,14 @@
 FROM python:3.8-bullseye
 
-COPY ./requirements-pre.txt ./requirements.txt /
+RUN mkdir -p /opt/decider
 
-RUN pip install --no-cache-dir -r /requirements-pre.txt && \
-    pip install --no-cache-dir -r /requirements.txt
+COPY ./requirements-pre.txt ./requirements.txt /opt/decider
 
-COPY ./app /app
-COPY ./docker/web/root_files/* /
-COPY ./decider.py /decider.py
+RUN pip install --no-cache-dir -r /opt/decider/requirements-pre.txt && \
+    pip install --no-cache-dir -r /opt/decider/requirements.txt
 
-ENTRYPOINT ["/bin/sh", "/entrypoint.sh"]
+COPY ./app /opt/decider/app
+COPY ./docker/web/root_files/* /opt/decider
+COPY ./decider.py /opt/decider/decider.py
+
+ENTRYPOINT ["/bin/sh", "/opt/decider/entrypoint.sh"]

--- a/docker/web/root_files/entrypoint.sh
+++ b/docker/web/root_files/entrypoint.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+
 # ensure environment variables are set
 if [ -z "$DB_HOSTNAME" ]; then
     echo "DB_HOSTNAME is not set"
@@ -33,13 +34,13 @@ if [ -z "$ADMIN_PASS" ]; then
     exit 1
 fi
 
+cd /opt/decider
+
 python create_user_json.py
 
-# initialise the database
+# build database
+# (if FULL_BUILD_MODE=preserve: only rebuild if no AttackVersion table or no versions in the table)
 python -m app.utils.db.actions.full_build --config DefaultConfig
-
-# run the app (DEVELOPMENT MODE)
-# python decider.py --config DefaultConfig
 
 # HTTP:
 if [ -z "$WEB_HTTPS_ON" ]; then
@@ -53,7 +54,7 @@ else
     echo "Running in HTTPS mode"
 
     # Cert Found:
-    if [ -f /app/utils/certs/decider.crt ] && [ -f /app/utils/certs/decider.key ]; then
+    if [ -f app/utils/certs/decider.crt ] && [ -f app/utils/certs/decider.key ]; then
 
         echo "SSL Cert Found"
 
@@ -63,19 +64,19 @@ else
         echo "SSL Cert Missing - Generating new one"
 
         # clear (1 could still exist, and .csr to be sure)
-        rm -f /app/utils/certs/decider.crt /app/utils/certs/decider.key /app/utils/certs/decider.csr
+        rm -f app/utils/certs/decider.crt app/utils/certs/decider.key app/utils/certs/decider.csr
 
         # generate
         openssl req \
             -x509 \
             -newkey rsa:4096 \
-            -keyout /app/utils/certs/decider.key \
-            -out /app/utils/certs/decider.crt \
+            -keyout app/utils/certs/decider.key \
+            -out app/utils/certs/decider.crt \
             -nodes \
             -sha256 \
             -days 365 \
             -subj "/C=US/ST=Virginia/L=McLean/O=Company Name/OU=Org/CN=www.example.com"
     fi
 
-    uwsgi --master --https 0.0.0.0:5000,/app/utils/certs/decider.crt,/app/utils/certs/decider.key --module decider:app
+    uwsgi --master --https 0.0.0.0:5000,app/utils/certs/decider.crt,app/utils/certs/decider.key --module decider:app
 fi

--- a/docs/install/CentOS_7.md
+++ b/docs/install/CentOS_7.md
@@ -104,11 +104,7 @@ cd ..
 sudo -u decider -g decider /opt/decider/python3.8.10/bin/python3.8 -m \
     venv /opt/decider/1.0.0/venv/ ;\
 sudo -u decider -g decider /opt/decider/1.0.0/venv/bin/python -m \
-    pip --no-cache-dir install pip==23.0.1 ;\
-sudo -u decider -g decider /opt/decider/1.0.0/venv/bin/python -m \
-    pip --no-cache-dir install setuptools==67.6.1 ;\
-sudo -u decider -g decider /opt/decider/1.0.0/venv/bin/python -m \
-    pip --no-cache-dir install wheel==0.40.0 ;\
+    pip --no-cache-dir install -r /opt/decider/1.0.0/requirements-pre.txt ;\
 sudo -u decider -g decider /opt/decider/1.0.0/venv/bin/python -m \
     pip --no-cache-dir install -r /opt/decider/1.0.0/requirements.txt
 ```

--- a/docs/install/Ubuntu_22.04.2.md
+++ b/docs/install/Ubuntu_22.04.2.md
@@ -89,11 +89,7 @@ cd ..
 sudo -u decider -g decider /opt/decider/python3.8.10/bin/python3.8 -m \
     venv /opt/decider/1.0.0/venv/
 sudo -u decider -g decider /opt/decider/1.0.0/venv/bin/python -m \
-    pip --no-cache-dir install pip==23.0.1
-sudo -u decider -g decider /opt/decider/1.0.0/venv/bin/python -m \
-    pip --no-cache-dir install setuptools==67.6.1
-sudo -u decider -g decider /opt/decider/1.0.0/venv/bin/python -m \
-    pip --no-cache-dir install wheel==0.40.0
+    pip --no-cache-dir install -r /opt/decider/1.0.0/requirements-pre.txt
 sudo -u decider -g decider /opt/decider/1.0.0/venv/bin/python -m \
     pip --no-cache-dir install -r /opt/decider/1.0.0/requirements.txt
 ```

--- a/docs/install/ubuntu_22_04_2.sh
+++ b/docs/install/ubuntu_22_04_2.sh
@@ -49,11 +49,7 @@ cd ..
 sudo -u decider -g decider /opt/decider/python3.8.10/bin/python3.8 -m \
     venv /opt/decider/1.0.0/venv/
 sudo -u decider -g decider /opt/decider/1.0.0/venv/bin/python -m \
-    pip --no-cache-dir install pip==23.0.1
-sudo -u decider -g decider /opt/decider/1.0.0/venv/bin/python -m \
-    pip --no-cache-dir install setuptools==67.6.1
-sudo -u decider -g decider /opt/decider/1.0.0/venv/bin/python -m \
-    pip --no-cache-dir install wheel==0.40.0
+    pip --no-cache-dir install -r /opt/decider/1.0.0/requirements-pre.txt
 sudo -u decider -g decider /opt/decider/1.0.0/venv/bin/python -m \
     pip --no-cache-dir install -r /opt/decider/1.0.0/requirements.txt
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,3 @@
-# Note - Post-Install Step
-# ------------------------
-# pre-commit install
-
 black==23.3.0
 certifi==2022.12.7
 cfgv==3.3.1

--- a/requirements-pre.txt
+++ b/requirements-pre.txt
@@ -1,0 +1,3 @@
+pip==23.0.1
+setuptools==67.6.1
+wheel==0.40.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,3 @@
-# Note - Install Order
-# --------------------
-# pip install pip==23.0.1
-# pip install setuptools==67.6.1
-# pip install wheel==0.40.0
-# pip install -r requirements.txt
-# pip install -r requirements-dev.txt
-
 bcrypt==4.0.1
 beautifulsoup4==4.12.1
 bleach==6.0.0


### PR DESCRIPTION
- Instead of loose install instructions, pip/wheel/setuptools versions now codified into requirements-pre.txt
  - Added to Docker install
  - Added to Ubuntu / CentOS guides
- Made Docker install into /opt/decider instead of /
- Removed dos2unix + apt update
  - Was an issue on my end - git-for-windows default is to checkout CRLF, which killed entrypoint.sh