### PR TITLE
Update cryptography / pypi licenses

### DIFF
--- a/app/routes/misc.py
+++ b/app/routes/misc.py
@@ -163,7 +163,7 @@ def export_cart_to_word():
       - tactsAndTechs's root level is in matrix tactic order
         - techniques within a tactic are in name alphabetical order
     {
-        appVersion: "1.0.0",
+        appVersion: "x.y.z",
 
         usages: {
             "tactId--techId": [

--- a/app/version.py
+++ b/app/version.py
@@ -1,7 +1,11 @@
-DECIDER_APP_VERSION = "1.0.0"
+DECIDER_APP_VERSION = "2.0.0"
 
 # Make sure to check: https://semver.org/
 #
 # Functionality changes should be documented in:
 # - user/admin guide(s)
 # - change-log.html
+
+# Bigger update in the works
+# - out-of-app changelog file will be used
+# - changlog page will be removed

--- a/pypi_licenses.txt
+++ b/pypi_licenses.txt
@@ -4,38 +4,65 @@ Tool available at: https://pypi.org/project/pip-licenses/
 Only a summary is given for PyPi/Pip packages as they are not being included or modified in the distribution of Decider.
 "requirements.txt" merely tells the user to download and use these packages in order to use Decider.
 
-Name                Version  License
-bcrypt              4.0.1    Apache Software License
-bleach              6.0.0    Apache Software License
-importlib-metadata  6.1.0    Apache Software License
-cryptography        40.0.1   Apache Software License; BSD License
-Flask               2.2.3    BSD License
-Flask-SQLAlchemy    3.0.3    BSD License
-Flask-WTF           1.1.1    BSD License
-Jinja2              3.1.2    BSD License
-Markdown            3.4.3    BSD License
-MarkupSafe          2.1.2    BSD License
-SQLAlchemy-Utils    0.40.0   BSD License
-WTForms             3.0.1    BSD License
-Werkzeug            2.2.3    BSD License
-click               8.1.3    BSD License
-itsdangerous        2.1.2    BSD License
-lxml                4.9.2    BSD License
-pycparser           2.21     BSD License
-python-dotenv       1.0.0    BSD License
-webencodings        0.5.1    BSD License
-boolean.py          4.0      BSD-2-Clause
-uWSGI               2.0.21   GNU General Public License v2 or later (GPLv2+)
-psycopg2-binary     2.9.6    GNU Library or Lesser General Public License (LGPL)
-Flask-Login         0.6.2    MIT License
-Flask-Principal     0.4.0    MIT License
-SQLAlchemy          1.4.47   MIT License
-beautifulsoup4      4.12.1   MIT License
-blinker             1.6      MIT License
-cffi                1.15.1   MIT License
-greenlet            2.0.2    MIT License
-pipdeptree          2.7.0    MIT License
-six                 1.16.0   MIT License
-soupsieve           2.4      MIT License
-zipp                3.15.0   MIT License
-typing_extensions   4.5.0    Python Software Foundation License
+ Name                Version    License
+ bcrypt              4.0.1      Apache Software License
+ bleach              6.0.0      Apache Software License
+ importlib-metadata  6.1.0      Apache Software License
+ requests            2.31.0     Apache Software License
+ cryptography        41.0.1     Apache Software License; BSD License
+ packaging           23.0       Apache Software License; BSD License
+ Flask               2.3.2      BSD License
+ Flask-SQLAlchemy    3.0.3      BSD License
+ Flask-WTF           1.1.1      BSD License
+ Jinja2              3.1.2      BSD License
+ Markdown            3.4.3      BSD License
+ MarkupSafe          2.1.2      BSD License
+ SQLAlchemy-Utils    0.40.0     BSD License
+ WTForms             3.0.1      BSD License
+ Werkzeug            2.3.3      BSD License
+ click               8.1.3      BSD License
+ idna                3.4        BSD License
+ itsdangerous        2.1.2      BSD License
+ lxml                4.9.2      BSD License
+ nodeenv             1.7.0      BSD License
+ pycparser           2.21       BSD License
+ python-dotenv       1.0.0      BSD License
+ webencodings        0.5.1      BSD License
+ boolean.py          4.0        BSD-2-Clause
+ uWSGI               2.0.21     GNU General Public License v2 or later (GPLv2+)
+ psycopg2-binary     2.9.6      GNU Library or Lesser General Public License (LGPL)
+ Flask-Login         0.6.2      MIT License
+ Flask-Principal     0.4.0      MIT License
+ PyYAML              6.0        MIT License
+ SQLAlchemy          1.4.47     MIT License
+ beautifulsoup4      4.12.1     MIT License
+ black               23.3.0     MIT License
+ blinker             1.6.2      MIT License
+ cffi                1.15.1     MIT License
+ cfgv                3.3.1      MIT License
+ charset-normalizer  3.1.0      MIT License
+ dparse              0.6.2      MIT License
+ flake8              6.0.0      MIT License
+ greenlet            2.0.2      MIT License
+ identify            2.5.22     MIT License
+ mccabe              0.7.0      MIT License
+ mypy-extensions     1.0.0      MIT License
+ platformdirs        3.2.0      MIT License
+ pre-commit          3.2.2      MIT License
+ pycodestyle         2.10.0     MIT License
+ pyflakes            3.0.1      MIT License
+ ruamel.yaml         0.17.21    MIT License
+ ruamel.yaml.clib    0.2.7      MIT License
+ safety              2.3.4      MIT License
+ six                 1.16.0     MIT License
+ soupsieve           2.4        MIT License
+ toml                0.10.2     MIT License
+ tomli               2.0.1      MIT License
+ urllib3             1.26.15    MIT License
+ virtualenv          20.21.0    MIT License
+ zipp                3.15.0     MIT License
+ certifi             2022.12.7  Mozilla Public License 2.0 (MPL 2.0)
+ pathspec            0.11.1     Mozilla Public License 2.0 (MPL 2.0)
+ distlib             0.3.6      Python Software Foundation License
+ typing_extensions   4.5.0      Python Software Foundation License
+ filelock            3.11.0     The Unlicense (Unlicense)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ blinker==1.6.2
 boolean.py==4.0
 cffi==1.15.1
 click==8.1.3
-cryptography==40.0.1
+cryptography==41.0.1
 Flask==2.3.2
 Flask-Login==0.6.2
 Flask-Principal==0.4.0


### PR DESCRIPTION
- requirements.txt: cryptography==(40.0.1 -&gt; 41.0.1)
- Decider 1.0.0 -&gt; 2.0.0
  - Cryptography update removes support for OpenSSL &lt; 1.1.1d - https://cryptography.io/en/latest/changelog/#v41-0-0