### PR TITLE
Tree Filtering: Tech->Subs Correction

### DIFF
--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -548,10 +548,10 @@ def answers_api_technique(args):
         )
         .join(
             technique_platform_map,
-            technique_platform_map.c.technique == Technique.uid,
+            technique_platform_map.c.technique == technique_alias.uid,
         )
         .join(Platform, technique_platform_map.c.platform == Platform.uid)
-        .outerjoin(technique_ds_map, technique_ds_map.c.technique == Technique.uid)
+        .outerjoin(technique_ds_map, technique_ds_map.c.technique == technique_alias.uid)
         .outerjoin(DataSource, technique_ds_map.c.data_source == DataSource.uid)
         .group_by(Technique.uid, technique_alias.uid)
     ).all()


### PR DESCRIPTION
Question Tree Filtering had an issue
- It would apply filters to the Base Technique on a Tech->Subs page
- That is, it wouldn't reduce the amount of options against the set filter after passing the Tactic->Tech page
- Now SubTechniques are properly filtered