### PR TITLE
New Tab External Links

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -70,6 +70,8 @@
             <span class="navbar-brand">
                 <a id="navCisaLogo"
                     href="https://www.cisa.gov/"
+                    target="_blank"
+                    rel="noreferrer noopener"
                     title="CISA.gov Website"
                     aria-label="CISA.gov Website"
                     class="text-decoration-none d-inline-block"

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -301,7 +301,12 @@
             GitHub Repo <i class="bi bi-github" aria-hidden="true"></i>
         </a><br>
         This project makes use of MITRE ATT&amp;CK&reg;<br>
-        <a href="https://attack.mitre.org/resources/terms-of-use/" class="link-light">
+        <a
+            href="https://attack.mitre.org/resources/terms-of-use/"
+            target="_blank"
+            rel="noreferrer noopener"
+            class="link-light"
+        >
             ATT&amp;CK Terms of Use
         </a>
     </footer>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -292,7 +292,12 @@
     {# Footer #}
     <footer id="deciderFooter" class="text-center w-100 py-3">
         Version: {{ g.decider_app_version }} &bull;
-        <a href="https://github.com/cisagov/decider" class="link-light icon-link">
+        <a
+            href="https://github.com/cisagov/decider"
+            target="_blank"
+            rel="noreferrer noopener"
+            class="link-light icon-link"
+        >
             GitHub Repo <i class="bi bi-github" aria-hidden="true"></i>
         </a><br>
         This project makes use of MITRE ATT&amp;CK&reg;<br>

--- a/app/templates/change-log.html
+++ b/app/templates/change-log.html
@@ -11,7 +11,12 @@
         <strong>Note:</strong> this changelog has been deprecated.<br><br>
 
         You should check out the
-        <a href="https://github.com/cisagov/decider" class="icon-link">
+        <a
+            href="https://github.com/cisagov/decider"
+            target="_blank"
+            rel="noreferrer noopener"
+            class="icon-link"
+        >
             GitHub Repo <i class="bi bi-github" aria-hidden="true"></i>
         </a>
         for updates instead.<br>

--- a/app/templates/success.html
+++ b/app/templates/success.html
@@ -53,6 +53,8 @@
         <h1 class="fs-2" id="successTechNameHeader" class="mb-2">
             <span>{{ success.name }} [</span><a
                 :href="resolveURL($store.success.url)"
+                target="_blank"
+                rel="noreferrer noopener"
                 class="link-attack-orange"
                 aria-label="`ATT&amp;CK Page {{ success.name }} {{ success.id }}`"
             >{{ success.id }}</a><span>]</span>

--- a/app/templates/success.html
+++ b/app/templates/success.html
@@ -248,13 +248,23 @@
                     <tr :class="(index % 2 == 0) ? 'table-light' : ''">
                         <td class="align-middle text-break" x-html="example.sentence" :rowspan="example.links.length"></td>
                         <td class="align-middle text-break">
-                            <a :href="resolveURL(example.links[0].url)" x-text="example.links[0].name"></a>
+                            <a
+                                :href="resolveURL(example.links[0].url)"
+                                target="_blank"
+                                rel="noreferrer noopener"
+                                x-text="example.links[0].name"
+                            ></a>
                         </td>
                     </tr>
                     <template x-for="link in example.links.slice(1)" :key="link.appId">
                         <tr :class="(index % 2 == 0) ? 'table-light' : ''">
                             <td class="align-middle text-break">
-                                <a :href="resolveURL(link.url)" x-text="link.name"></a>
+                                <a
+                                    :href="resolveURL(link.url)"
+                                    target="_blank"
+                                    rel="noreferrer noopener"
+                                    x-text="link.name"
+                                ></a>
                             </td>
                         </tr>
                     </template>


### PR DESCRIPTION
Ensure that external Links open in a new tab:

- CISA Homepage
- GitHub Repo
- ATT&amp;CK Terms of Service
- Success Page Tech ID ATT&amp;CK Link
- Success Page Usage Example Reports