### PR TITLE
Tweak Search: don't use ZWS as it wasn't an ignorable space

### DIFF
--- a/app/routes/search.py
+++ b/app/routes/search.py
@@ -442,7 +442,11 @@ class PSQLTxt:
 
     @staticmethod
     def zwspace_pad_special(txt):
-        return f"regexp_replace({txt}, '([^a-z0-9 ]+)', '\u200B\\1\u200B', 'gi')"
+        """Surrounds runs of special characters with hair-spaces
+            - Splits on specials as a form of tokenization
+            - Minimally alters visual output
+        """
+        return f"regexp_replace({txt}, '([^a-z0-9 ]+)', '\u200A\\1\u200A', 'gi')"
 
     @staticmethod
     def basic_headline(txt, qry):

--- a/app/static/css/decider.css
+++ b/app/static/css/decider.css
@@ -326,7 +326,7 @@ body {
 }
 
 .answer-card .card-header mark {
-    padding: 0.1rem !important;
+    padding: 0 !important;
     background-color: inherit;
     color: inherit;
     text-decoration-line: underline;
@@ -336,7 +336,7 @@ body {
     text-decoration-skip-ink: none;
 }
 .answer-card .card-body mark {
-    padding: 0.1rem !important;
+    padding: 0 !important;
     background-color: inherit;
     color: inherit;
     text-decoration-line: underline;


### PR DESCRIPTION
Replaced u200B (Zero Width Space) with u200A (Hair Space).

This keeps proper tokenization / splitting at special<->normal boundaries in search, while having minimal visual impact on output.

u200B caused issues in `ts_headline` where it wouldn't highlight words touching a u200B.