### PR TITLE
uWSGI: remove broken dynamic compression that'd cause rev proxy 502's

### DIFF
--- a/docker/web/root_files/uwsgi-http-kiosk.ini
+++ b/docker/web/root_files/uwsgi-http-kiosk.ini
@@ -27,33 +27,5 @@ offload-threads = 4
 static-expires = .* %(24 * 60 * 60)
 static-gzip-all = true
 
-# Apply conditional gzip encoding
-collect-header = Content-Type RESPONSE_CONTENT_TYPE
-collect-header = Content-Length RESPONSE_CONTENT_LENGTH
-
-# uWSGI internal are not that smart, thus no content-length means it's 0
-response-route-if = empty:${RESPONSE_CONTENT_LENGTH} goto:no-length
-
-# Don't bother compressing 1kb responses, not worth the trouble
-response-route-if = islower:${RESPONSE_CONTENT_LENGTH};1024 last:
-response-route-label = no-length
-
-# Make sure the client actually wants gzip
-response-route-if = contains:${HTTP_ACCEPT_ENCODING};gzip goto:check-response
-response-route-run = last:
-response-route-label = check-response
-
-# Don't bother compressing non-text stuff, usually not worth it
-response-route-if = equal:${RESPONSE_CONTENT_TYPE};application/json goto:apply-gzip
-response-route-if = startswith:${RESPONSE_CONTENT_TYPE};text/ goto:apply-gzip
-response-route-run = last:
-response-route-label = apply-gzip
-response-route-run = gzip:
-
-# Why apply this filter too you wonder? The gzip transformation is not smart
-# enough to chunk the body or set a Content-Length, thus keepalive will be broken
-response-route-run = chunked:
-
-# references / credits:
-# - https://blog.ionelmc.ro/2022/03/14/how-to-run-uwsgi/
-# - https://ugu.readthedocs.io/en/latest/compress.html
+; currently no dynamic content compression
+; biggest impact would be for the full search responses

--- a/docker/web/root_files/uwsgi-https-kiosk.ini
+++ b/docker/web/root_files/uwsgi-https-kiosk.ini
@@ -27,33 +27,5 @@ offload-threads = 4
 static-expires = .* %(24 * 60 * 60)
 static-gzip-all = true
 
-# Apply conditional gzip encoding
-collect-header = Content-Type RESPONSE_CONTENT_TYPE
-collect-header = Content-Length RESPONSE_CONTENT_LENGTH
-
-# uWSGI internal are not that smart, thus no content-length means it's 0
-response-route-if = empty:${RESPONSE_CONTENT_LENGTH} goto:no-length
-
-# Don't bother compressing 1kb responses, not worth the trouble
-response-route-if = islower:${RESPONSE_CONTENT_LENGTH};1024 last:
-response-route-label = no-length
-
-# Make sure the client actually wants gzip
-response-route-if = contains:${HTTP_ACCEPT_ENCODING};gzip goto:check-response
-response-route-run = last:
-response-route-label = check-response
-
-# Don't bother compressing non-text stuff, usually not worth it
-response-route-if = equal:${RESPONSE_CONTENT_TYPE};application/json goto:apply-gzip
-response-route-if = startswith:${RESPONSE_CONTENT_TYPE};text/ goto:apply-gzip
-response-route-run = last:
-response-route-label = apply-gzip
-response-route-run = gzip:
-
-# Why apply this filter too you wonder? The gzip transformation is not smart
-# enough to chunk the body or set a Content-Length, thus keepalive will be broken
-response-route-run = chunked:
-
-# references / credits:
-# - https://blog.ionelmc.ro/2022/03/14/how-to-run-uwsgi/
-# - https://ugu.readthedocs.io/en/latest/compress.html
+; currently no dynamic content compression
+; biggest impact would be for the full search responses


### PR DESCRIPTION
Title has it all.

May re-enable in the future; however, most pages / responses aren't large enough to warrant it.

Full search can be large, so that could be paginated at some point.